### PR TITLE
Add NEW CHAT button to sidebar for conversation reset

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -51,6 +51,15 @@ class CourseStats(BaseModel):
     total_courses: int
     course_titles: List[str]
 
+class SessionClearRequest(BaseModel):
+    """Request model for clearing a session"""
+    session_id: str
+
+class SessionClearResponse(BaseModel):
+    """Response model for session clearing"""
+    success: bool
+    message: str
+
 # API Endpoints
 
 @app.post("/api/query", response_model=QueryResponse)
@@ -84,6 +93,21 @@ async def get_course_stats():
         )
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
+
+@app.post("/api/session/clear", response_model=SessionClearResponse)
+async def clear_session(request: SessionClearRequest):
+    """Clear a conversation session"""
+    try:
+        rag_system.session_manager.clear_session(request.session_id)
+        return SessionClearResponse(
+            success=True,
+            message=f"Session {request.session_id} cleared successfully"
+        )
+    except Exception as e:
+        return SessionClearResponse(
+            success=False,
+            message=f"Error clearing session: {str(e)}"
+        )
 
 @app.on_event("startup")
 async def startup_event():

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -19,6 +19,11 @@
         <div class="main-content">
             <!-- Left Sidebar -->
             <aside class="sidebar">
+                <!-- New Chat Button -->
+                <div class="sidebar-section">
+                    <button class="new-chat-button" id="newChatButton">NEW CHAT</button>
+                </div>
+
                 <!-- Course Stats -->
                 <div class="sidebar-section">
                     <details class="stats-collapsible">

--- a/frontend/script.js
+++ b/frontend/script.js
@@ -5,7 +5,7 @@ const API_URL = '/api';
 let currentSessionId = null;
 
 // DOM elements
-let chatMessages, chatInput, sendButton, totalCourses, courseTitles;
+let chatMessages, chatInput, sendButton, totalCourses, courseTitles, newChatButton;
 
 // Initialize
 document.addEventListener('DOMContentLoaded', () => {
@@ -15,6 +15,7 @@ document.addEventListener('DOMContentLoaded', () => {
     sendButton = document.getElementById('sendButton');
     totalCourses = document.getElementById('totalCourses');
     courseTitles = document.getElementById('courseTitles');
+    newChatButton = document.getElementById('newChatButton');
     
     setupEventListeners();
     createNewSession();
@@ -28,6 +29,9 @@ function setupEventListeners() {
     chatInput.addEventListener('keypress', (e) => {
         if (e.key === 'Enter') sendMessage();
     });
+
+    // New Chat functionality
+    newChatButton.addEventListener('click', handleNewChat);
     
     
     // Suggested questions
@@ -164,6 +168,28 @@ async function createNewSession() {
     currentSessionId = null;
     chatMessages.innerHTML = '';
     addMessage('Welcome to the Course Materials Assistant! I can help you with questions about courses, lessons and specific content. What would you like to know?', 'assistant', null, true);
+}
+
+async function handleNewChat() {
+    try {
+        // Clear session on backend if session exists
+        if (currentSessionId) {
+            await fetch(`${API_URL}/session/clear`, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({
+                    session_id: currentSessionId
+                })
+            });
+        }
+    } catch (error) {
+        console.log('Session clear request failed, continuing with frontend reset');
+    }
+
+    // Reset frontend state
+    createNewSession();
 }
 
 // Load course statistics

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -481,13 +481,32 @@ header h1 {
     letter-spacing: 0.5px;
 }
 
+/* New Chat Button */
+.new-chat-button {
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: var(--text-secondary);
+    cursor: pointer;
+    padding: 0.5rem 0;
+    border: none;
+    background: none;
+    outline: none;
+    transition: all 0.2s ease;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    width: 100%;
+    text-align: left;
+}
+
 .stats-header:focus,
-.suggested-header:focus {
+.suggested-header:focus,
+.new-chat-button:focus {
     color: var(--primary-color);
 }
 
 .stats-header:hover,
-.suggested-header:hover {
+.suggested-header:hover,
+.new-chat-button:hover {
     color: var(--primary-color);
 }
 


### PR DESCRIPTION
- Added NEW CHAT button above Courses section in left sidebar
- Implemented frontend click handler with proper session cleanup
- Added backend /api/session/clear endpoint for session management
- Styled button to match existing sidebar section headers
- Provides clean conversation reset without page reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)